### PR TITLE
Sync Hyperion.NG with upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,9 +92,14 @@ jobs:
             -DENABLE_DEV_SERIAL=OFF \
             -DENABLE_DEV_TINKERFORGE=OFF \
             -DENABLE_DEV_USB_HID=OFF \
-            -DENABLE_AVAHI=OFF \
             -DENABLE_EFFECTENGINE=OFF \
             -DENABLE_REMOTE_CTL=OFF \
+            -DENABLE_QT=OFF \
+            -DENABLE_FORWARDER=OFF \
+            -DENABLE_DEV_SPI=OFF \
+            -DENABLE_MDNS=OFF \
+            -DENABLE_FLATBUF_CONNECT=ON \
+            -DENABLE_PROTOBUF_SERVER=OFF \
             -Wno-dev
           make
           popd
@@ -118,7 +123,7 @@ jobs:
             -DENABLE_DEV_USB_HID=ON \
             -DENABLE_DEV_WS281XPWM=OFF \
             -DENABLE_DEV_TINKERFORGE=ON \
-            -DENABLE_AVAHI=OFF \
+            -DENABLE_MDNS=OFF \
             -DENABLE_DEPLOY_DEPENDENCIES=OFF \
             -DENABLE_BOBLIGHT_SERVER=ON \
             -DENABLE_FLATBUF_SERVER=ON \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          repository: tuxuser/hyperion.ng
-          ref: tmp/webos/lil_patches
+          repository: hyperion-project/hyperion.ng
+          ref: e055fb9e15301a5cedfc8ce8c82f267a16d4a45f
           path: hyperion.ng
           submodules: recursive
+
+      - name: Patch sources (force link w/ librt)
+        run: sed -i -e 's/hidapi-libusb)$/rt hidapi-libusb)/g w /dev/stdout' libsrc/leddevice/CMakeLists.txt
 
       - name: Restore/Cache build directories
         uses: actions/cache@v3


### PR DESCRIPTION
Use hyperion-project/hyperion.ng branch: master, commit: https://github.com/hyperion-project/hyperion.ng/commit/e055fb9e15301a5cedfc8ce8c82f267a16d4a45f

Does inline patching with `sed`, both in CI and in build_hyperion_ng.sh:

Invocation: `sed -i -e 's/hidapi-libusb)$/rt hidapi-libusb)/g w /dev/stdout' libsrc/leddevice/CMakeLists.txt`