### PR TITLE
build: Do not patch in force-linking to librt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,6 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Patch sources (force link w/ librt)
-        run: sed -i -e 's/hidapi-libusb)$/rt hidapi-libusb)/g w /dev/stdout' libsrc/leddevice/CMakeLists.txt
-
       - name: Restore/Cache build directories
         uses: actions/cache@v3
         with:

--- a/build_hyperion_ng.sh
+++ b/build_hyperion_ng.sh
@@ -2,8 +2,6 @@
 # Usage:
 # TOOLCHAIN_DIR=<path_to_webos_buildroot_toolchain> ./build_hyperion_ng.sh
 
-PATCH_LIBRT="yes"
-
 HYPERION_NG_REPO="${HYPERION_NG_REPO:-https://github.com/hyperion-project/hyperion.ng}"
 HYPERION_NG_BRANCH="${HYPERION_NG_BRANCH:-master}"
 
@@ -27,12 +25,6 @@ if [ ! -d $HYPERION_NG_DIR ]
 then
   echo ":: Cloning hyperion.ng from repo '$HYPERION_NG_REPO', branch: '$HYPERION_NG_BRANCH'"
   git clone --recursive --branch $HYPERION_NG_BRANCH $HYPERION_NG_REPO $HYPERION_NG_DIR || { echo "[-] Cloning git repo failed"; exit 1; }
-  
-  if [ ! -z $PATCH_LIBRT ]
-  then
-    echo "* Patching to force-link librt"
-    sed -i -e 's/hidapi-libusb)$/rt hidapi-libusb)/g w /dev/stdout' hyperion.ng/libsrc/leddevice/CMakeLists.txt
-  fi
 fi
 
 # Native build to have flatc compiler


### PR DESCRIPTION
Existance of `clock_gettime` and if linking with librt is required is now checked in hyperion.ng itself.

References:
https://github.com/hyperion-project/hyperion.ng/commit/d777c47d3bee6002ad8d583c06b2a146e41b97ea
https://github.com/hyperion-project/hyperion.ng/pull/1467