### PR TITLE
More stable elevation

### DIFF
--- a/frontend/views/MainPanel.js
+++ b/frontend/views/MainPanel.js
@@ -102,16 +102,11 @@ module.exports = kind({
   create: function () {
     this.inherited(arguments);
     console.info("Application created");
-    this.set('resultText', 'Waiting for startup...');
-    // Spawn startup routine after 2 seconds, so UI has time to load
-    var self = this;
-    setTimeout(function() {
-      self.doStartup();
-    }, 3000);
+    this.doStartup();
   },
-  // Spawned from this.create() with a little delay
+  // Spawned from this.create()
   doStartup: function() {
-    this.set('resultText', 'Startup routine started...');
+    this.set('resultText', 'Waiting for service status data...');
     var self = this;
     // Start to continuosly poll service status
     setInterval(function () {

--- a/frontend/views/MainPanel.js
+++ b/frontend/views/MainPanel.js
@@ -57,7 +57,7 @@ module.exports = kind({
               text: 'unknown',
               disabled: true,
             },
-            {kind: ToggleItem, name: "autostart", content: 'Autostart', checked: true, disabled: true, onchange: "autostartToggle"},
+            {kind: ToggleItem, name: "autostart", content: 'Autostart', checked: false, disabled: true, onchange: "autostartToggle"},
             {kind: Item, name: 'startButton', content: 'Start', ontap: "start", disabled: true},
             {kind: Item, name: 'stopButton', content: 'Stop', ontap: "stop", disabled: true},
             {kind: Item, name: 'rebootButton', content: 'Reboot system', ontap: "reboot"},
@@ -74,8 +74,8 @@ module.exports = kind({
     {kind: LunaService, name: 'stop', service: 'luna://org.webosbrew.hyperion.ng.loader.service', method: 'stop', onResponse: 'onDaemonStop', onError: 'onDaemonStop'},
     {kind: LunaService, name: 'version', service: 'luna://org.webosbrew.hyperion.ng.loader.service', method: 'version', onResponse: 'onDaemonVersion', onError: 'onDaemonVersion'},
     {kind: LunaService, name: 'terminate', service: 'luna://org.webosbrew.hyperion.ng.loader.service', method: 'terminate', onResponse: 'onTermination', onError: 'onTermination'},
-    {kind: LunaService, name: 'autostartStatusCheck', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onAutostartCheck', onError: 'onAutostartCheck'},
 
+    {kind: LunaService, name: 'autostartStatusCheck', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onAutostartCheck', onError: 'onAutostartCheck'},
     {kind: LunaService, name: 'exec', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onExec', onError: 'onExec'},
     {kind: LunaService, name: 'systemReboot', service: 'luna://org.webosbrew.hbchannel.service', method: 'reboot' }
   ],
@@ -87,12 +87,14 @@ module.exports = kind({
   resultText: 'unknown',
 
   initDone: false,
+  autostartStatusChecked: false,
 
   bindings: [
+    {from: "autostartStatusChecked", to: '$.autostart.disabled', transform: not},
     {from: "autostartEnabled", to: '$.autostart.checked'},
+
     {from: "serviceElevated", to: '$.startButton.disabled', transform: not},
     {from: "serviceElevated", to: '$.stopButton.disabled', transform: not},
-    {from: "serviceElevated", to: '$.autostart.disabled', transform: not},
     {from: "hyperionVersionText", to: '$.hyperionVersion.text'},
     {from: "serviceElevated", to: '$.elevationStatus.text', transform: yes_no_bool},
     {from: "daemonRunning", to: '$.daemonStatus.text', transform: yes_no_bool},
@@ -192,6 +194,7 @@ module.exports = kind({
     // this.$.result.set('content', JSON.stringify(evt.data));
     this.set('autostartEnabled', (evt.returnValue && evt.stdoutString && evt.stdoutString.trim() == autostartFilepath));
     this.set('resultText', 'Autostart check completed');
+    this.set('autostartStatusChecked', true);
   },
   onTermination: function (sender, evt) {
     console.info("onTermination");

--- a/frontend/views/MainPanel.js
+++ b/frontend/views/MainPanel.js
@@ -24,10 +24,6 @@ var yes_no_bool = function (x) {
     return "No";
 }
 
-const sleep = (duration) => {
-  return new Promise(resolve => setTimeout(resolve, duration));
-}
-
 module.exports = kind({
   name: 'MainPanel',
   kind: Panel,

--- a/frontend/views/MainPanel.js
+++ b/frontend/views/MainPanel.js
@@ -14,7 +14,7 @@ var serviceName = "org.webosbrew.hyperion.ng.loader.service";
 var servicePath = "/media/developer/apps/usr/palm/services/" + serviceName;
 var autostartFilepath = servicePath + "/autostart.sh";
 var linkPath = "/var/lib/webosbrew/init.d/90-start_hyperiond";
-var elevationCommand = "/media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service/elevate-service " + serviceName;
+var elevationCommand = "/media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service/elevate-service " + serviceName + " && killall -9 loader_service";
 
 var not = function (x) { return !x };
 var yes_no_bool = function (x) {
@@ -89,6 +89,8 @@ module.exports = kind({
   hyperionVersionText: 'unknown',
   resultText: 'unknown',
 
+  initDone: false,
+
   bindings: [
     {from: "autostartEnabled", to: '$.autostart.checked'},
     {from: "serviceElevated", to: '$.startButton.disabled', transform: not},
@@ -103,11 +105,21 @@ module.exports = kind({
   create: function () {
     this.inherited(arguments);
     console.info("Application created");
-    // At first, elevate the native service
-    // It does not do harm if service is elevated already
-    this.elevate();
-    this.set('resultText','Checking service status...');
-    this.$.serviceStatus.send({});
+    this.set('resultText', 'Waiting for startup...');
+    // Spawn startup routine after 2 seconds, so UI has time to load
+    var self = this;
+    setTimeout(function() {
+      self.doStartup();
+    }, 3000);
+  },
+  // Spawned from this.create() with a little delay
+  doStartup: function() {
+    this.set('resultText', 'Startup routine started...');
+    var self = this;
+    // Start to continuosly poll service status
+    setInterval(function () {
+      self.$.serviceStatus.send({});
+    }, 2000);
   },
   // Elevates the native service - this enables hyperion.ng.loader.service to run as root by default
   elevate: function () {
@@ -161,15 +173,24 @@ module.exports = kind({
   onServiceStatus: function (sender, evt) {
     console.info("onServiceStatus");
     console.info(sender, evt);
+
+    if (!evt.returnValue) {
+      console.info('Service status call failed!');
+      return;
+    }
+
     this.set('serviceElevated', evt.elevated);
     this.set('daemonRunning', evt.running);
-    this.set('resultText', 'Service status received..');
-    if (this.serviceElevated) {
+    if (this.serviceElevated && !this.initDone) {
+      this.set('resultText', 'Startup routine finished!');
+      this.initDone = true;
       this.checkAutostart();
       this.fetchVersion();
-    } else {
-      this.set('resultText', 'Restarting native service to elevate...');
-      this.terminate();
+    } else if (!this.serviceElevated) {
+      // Elevate the native service
+      // Eventually the next service status callback will report elevation
+      this.set('resultText', 'Trying to elevate...');
+      this.elevate();
     }
   },
   onAutostartCheck: function (sender, evt) {

--- a/frontend/views/MainPanel.js
+++ b/frontend/views/MainPanel.js
@@ -76,7 +76,8 @@ module.exports = kind({
     {kind: LunaService, name: 'terminate', service: 'luna://org.webosbrew.hyperion.ng.loader.service', method: 'terminate', onResponse: 'onTermination', onError: 'onTermination'},
     {kind: LunaService, name: 'autostartStatusCheck', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onAutostartCheck', onError: 'onAutostartCheck'},
 
-    {kind: LunaService, name: 'exec', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onExec', onError: 'onExec'}
+    {kind: LunaService, name: 'exec', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onExec', onError: 'onExec'},
+    {kind: LunaService, name: 'systemReboot', service: 'luna://org.webosbrew.hbchannel.service', method: 'reboot' }
   ],
 
   autostartEnabled: false,
@@ -129,7 +130,7 @@ module.exports = kind({
   },
   reboot: function () {
     console.info("Sending reboot command");
-    this.$.exec.send({command: 'reboot'});
+    this.$.systemReboot.send({});
   },
   start: function () {
     console.info("Start clicked");

--- a/frontend/views/MainPanel.js
+++ b/frontend/views/MainPanel.js
@@ -106,6 +106,8 @@ module.exports = kind({
   },
   // Spawned from this.create()
   doStartup: function() {
+    console.info('doStartup');
+    this.checkAutostart();
     this.set('resultText', 'Waiting for service status data...');
     var self = this;
     // Start to continuosly poll service status
@@ -176,7 +178,6 @@ module.exports = kind({
     if (this.serviceElevated && !this.initDone) {
       this.set('resultText', 'Startup routine finished!');
       this.initDone = true;
-      this.checkAutostart();
       this.fetchVersion();
     } else if (!this.serviceElevated) {
       // Elevate the native service

--- a/frontend/views/MainPanel.js
+++ b/frontend/views/MainPanel.js
@@ -193,7 +193,6 @@ module.exports = kind({
     console.info(sender, evt);
     // this.$.result.set('content', JSON.stringify(evt.data));
     this.set('autostartEnabled', (evt.returnValue && evt.stdoutString && evt.stdoutString.trim() == autostartFilepath));
-    this.set('resultText', 'Autostart check completed');
     this.set('autostartStatusChecked', true);
   },
   onTermination: function (sender, evt) {

--- a/frontend/views/MainPanel.js
+++ b/frontend/views/MainPanel.js
@@ -80,8 +80,7 @@ module.exports = kind({
     {kind: LunaService, name: 'terminate', service: 'luna://org.webosbrew.hyperion.ng.loader.service', method: 'terminate', onResponse: 'onTermination', onError: 'onTermination'},
     {kind: LunaService, name: 'autostartStatusCheck', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onAutostartCheck', onError: 'onAutostartCheck'},
 
-    {kind: LunaService, name: 'exec', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onExec', onError: 'onExec'},
-    {kind: LunaService, name: 'systemReboot', service: 'luna://org.webosbrew.hbchannel.service', method: 'reboot'},
+    {kind: LunaService, name: 'exec', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onExec', onError: 'onExec'}
   ],
 
   autostartEnabled: false,
@@ -122,7 +121,7 @@ module.exports = kind({
   },
   reboot: function () {
     console.info("Sending reboot command");
-    this.$.systemReboot.send({reason: 'SwDownload'});
+    this.$.exec.send({command: 'reboot'});
   },
   start: function () {
     console.info("Start clicked");

--- a/frontend/views/MainPanel.js
+++ b/frontend/views/MainPanel.js
@@ -77,6 +77,7 @@ module.exports = kind({
 
     {kind: LunaService, name: 'autostartStatusCheck', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onAutostartCheck', onError: 'onAutostartCheck'},
     {kind: LunaService, name: 'exec', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec', onResponse: 'onExec', onError: 'onExec'},
+    {kind: LunaService, name: 'execSilent', service: 'luna://org.webosbrew.hbchannel.service', method: 'exec'},
     {kind: LunaService, name: 'systemReboot', service: 'luna://org.webosbrew.hbchannel.service', method: 'reboot' }
   ],
 
@@ -120,7 +121,7 @@ module.exports = kind({
   // Elevates the native service - this enables hyperion.ng.loader.service to run as root by default
   elevate: function () {
     console.info("Sending elevation command");
-    this.$.exec.send({command: elevationCommand});
+    this.$.execSilent.send({command: elevationCommand});
   },
   // Kill the loader service. Needed to force-restart after elevation
   terminate: function() {


### PR DESCRIPTION
- Continously poll for status message
- Use a little delay before sending off first luna-service request
- Fix: reboot breaking WiFi functionality by using hbchannel.reboot with empty payload `{}` instead of `{reason: 'SwUpdate'}` (webOS 3.x)
- Fix: JS compatibility - `let` -> `var`, remove unused `const`-function (webOS 3.x)