### PR TITLE
Update iconColor in appinfo.json

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -8,7 +8,7 @@
   "splashBackground": "assets/splash_1080p.png",
   "bgImage": "assets/splash_1080p.png",
   "main": "index.html",
-  "iconColor": "black",
+  "iconColor": "#000000",
   "type": "web",
   "supportGIP": true,
   "appDescription": "Hyperion.NG for WebOS"


### PR DESCRIPTION
webOS 25 fails to render iconColor stated as color name (i.e. "black"), hex color code is required.
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/8a45b48c-0f0d-48d4-b592-0f511148b6ec" />
